### PR TITLE
Update API route prefixes and standardize route strings

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -14,7 +14,7 @@ def create_app():
     from .routes.test import test_routes # Registering new test route for backend verification
     
     # Register image-related routes under /api/image
-    app.register_blueprint(image_routes)
+    app.register_blueprint(image_routes, url_prefix="/api/image") # This allows image upload and color extraction functionality
 
     # Register test routes under /api/test
     app.register_blueprint(test_routes) # This allows quick health checks of the backend

--- a/backend/app/routes/image.py
+++ b/backend/app/routes/image.py
@@ -15,7 +15,7 @@ ALLOWED_EXTENSIONS = {'jpg', 'jpeg', 'png'}
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
-@image_routes.route("/upload", methods=["POST"])
+@image_routes.route('/upload', methods=["POST"])
 def upload_image():
     # Get the file from the request payload
     file = request.files.get('image')

--- a/backend/app/routes/test.py
+++ b/backend/app/routes/test.py
@@ -6,7 +6,7 @@ from flask import Blueprint, jsonify
 test_routes = Blueprint("test_routes", __name__)
 
 # Define a simple GET route to verify the API is responsive
-@test_routes.route("/api/test", methods=["GET"])
+@test_routes.route('/api/test', methods=["GET"])
 def test_api():
     # Return a JSON response with a success message and HTTP 200 status
     return jsonify({


### PR DESCRIPTION
Set url_prefix for image routes to '/api/image' in app initialization for clearer API structure. Standardized route string quotes in image and test routes for consistency.