### PR TITLE
📝 docs: Improve `api_theme` Endpoint Docstrings and Comments

### DIFF
--- a/backend/app/routes/theme.py
+++ b/backend/app/routes/theme.py
@@ -1,0 +1,36 @@
+"""
+Theme Route
+- Exposes POST /api/theme endpoint
+- Accepts a JSON body with 'palette': list of hex colors
+- Returns a JSON with 'theme': one of 'Spring', 'Summer', 'Autumn', 'Winter', 'Neutral'
+"""
+
+from flask import Blueprint, request, jsonify
+from app.services.theme_matcher import match_theme
+
+# Blueprint allows modular route registration
+theme_bp = Blueprint("theme_bp", __name__)
+
+# POST /api/theme
+@theme_bp.route("/api/theme", methods=["POST"])
+def api_theme():
+    """ 
+    Handle POST /api/theme 
+    - Expect JSON: {'palette': ['#aabbcc', ...]} 
+    - Returns: {"theme": "Spring"} or error message
+    """
+
+    # Parse JSON safely
+    data = request.get_json(force=True, silent=True)
+    if not data or 'palette' not in data:
+        return jsonify({"error": "Palette missing in request body"}), 400
+    
+    palette = data.get("palette", [])
+
+    try:
+        # Match palette to a seasonal theme
+        theme = match_theme(palette)
+        return jsonify({"theme": theme}), 200
+    except Exception as e:
+        # Catch-all for unexpected errors
+        return jsonify({"error": f"Failed to match theme: {str(e)}"}), 500


### PR DESCRIPTION
**Summary:**

This PR enhances the `api_theme` endpoint by adding detailed docstrings, clarifying variable usage, and improving modularity explanations. Exception handling is documented, and the Blueprint’s purpose is explained to support maintainability and readability.

---

**Changes Made:**

- ✅ Added **module-level docstring** explaining the endpoint’s purpose  
- ✅ Added **function docstring** for `api_theme`, detailing input and output  
- ✅ Clarified variable naming and expected structure with inline comments (`data`, `palette`)  
- ✅ Documented **catch-all exception handling** for unexpected errors  
- ✅ Added comment explaining the purpose of the **Blueprint** for modular route organization  

---

**Before vs After:**

| Area                  | Before            | After                                                      |
| --------------------- | ----------------- | ---------------------------------------------------------- |
| Docstring             | Minimal           | ✅ Module-level docstring explaining endpoint purpose     |
| Function comments     | None              | ✅ Detailed docstring explaining input/output for `api_theme` |
| Variable naming       | `data`, `palette` | ✅ Comments clarify expected structure and purpose        |
| Exception handling    | Bare              | ✅ Commented as catch-all for unexpected errors           |
| Blueprint explanation | None              | ✅ Added comment on purpose of Blueprint for modularity   |

---

**Why It Matters:**

- Improves readability and maintainability for future contributors  
- Supports onboarding of beginners with clear explanations  
- Enhances debugging by documenting expected data structures and exception handling  
- Clarifies Blueprint usage for modular backend architecture  

---

**Next Steps:**

- [ ] Add type hints for function parameters and return values  
- [ ] Write unit tests for edge cases in `api_theme` input handling  
