### PR TITLE
✨ feat: Register `/api/theme` Blueprint and Add Documentation

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,14 @@
 # backend/app/__init__.py
+"""
+Flask app factory
+- Initializes Flask instance
+- Enables CORS for frontend-backend communication
+- Registers Blueprints for modular routes:
+  - image routes (/api/image)
+  - test routes (/api/test)
+  - theme routes (/api/theme) ← newly added
+"""
+
 from flask import Flask
 from flask_cors import CORS # Allows cross-origin requests (essential for frontend-backend communication)
 
@@ -12,12 +22,16 @@ def create_app():
     # Import and register the image-related routes as a blueprint
     from .routes.image import image_routes
     from .routes.test import test_routes # Registering new test route for backend verification
+    from .routes.theme import theme_bp # Import the new theme routes
     
     # Register image-related routes under /api/image
     app.register_blueprint(image_routes, url_prefix="/api/image") # This allows image upload and color extraction functionality
 
     # Register test routes under /api/test
     app.register_blueprint(test_routes) # This allows quick health checks of the backend
+
+    # Register theme-related routes under /api/theme
+    app.register_blueprint(theme_bp) # This allows palette to theme matching functionality
 
     # Return the fully configured app instance
     return app


### PR DESCRIPTION
**Summary:**

This PR integrates the new `/api/theme` route by importing and registering `theme_bp` as a Blueprint. Documentation is added at both module and comment levels to clarify the purpose and usage of all Blueprints in the backend.

---

**Changes Made:**

- ✅ Imported `theme_bp` and registered it as a Blueprint in the app factory  
- ✅ Added comments describing the purpose of the new `/api/theme` route  
- ✅ Added a **top-level module docstring** explaining all registered Blueprints  

---

**Before vs After:**

| Area        | Before                           | After                                               |
| ----------- | -------------------------------- | --------------------------------------------------- |
| Theme route | Not present                      | ✅ Imported `theme_bp` and registered as a Blueprint |
| Comments    | Only image/test routes explained | ✅ Added notes about the new `/api/theme` route     |
| Docstring   | Module had none                  | ✅ Added top-level docstring explaining all Blueprints |

---

**Why It Matters:**

- Enables modular and scalable routing for the `/api/theme` endpoint  
- Improves code clarity for future contributors  
- Provides a single reference point for all Blueprints in the backend  

---

**Next Steps:**

- [ ] Add unit tests for `/api/theme` route  
- [ ] Consider documenting each Blueprint route in a central README or API doc  
