### PR TITLE
Fix syntax error in get_recent_palettes definition

### DIFF
--- a/backend/app/services/palette_service.py
+++ b/backend/app/services/palette_service.py
@@ -50,7 +50,7 @@ def save_palette(image_url, colours, theme):
     _save_data(data)
     return entry
 
-def get_recent_palettes(limit=5)
+def get_recent_palettes(limit=5):
     """
     Retrieve the most recent colour palettes.
     - Default limit is 5 newest entries.


### PR DESCRIPTION
Added missing colon to the get_recent_palettes function definition to correct a syntax error.