### PR TITLE
Fix indentation for get_recent_palettes route

### DIFF
--- a/backend/app/routes/palettes.py
+++ b/backend/app/routes/palettes.py
@@ -50,8 +50,8 @@ def save_palette():
         # Catch-all for unexpected runtime errors
         return jsonify({"error": str(e)}), 500
     
-    @palettes_bp.route("/recent", methods=["GET"])
-    def get_recent_palettes():
+@palettes_bp.route("/recent", methods=["GET"])
+def get_recent_palettes():
         """
         Fetch the most recent palettes.
         Optional query param:


### PR DESCRIPTION
Corrected the indentation of the @palettes_bp.route decorator and get_recent_palettes function to ensure proper route registration in Flask.