### PR TITLE
Add palettes data and update .gitignore

### DIFF
--- a/backend/data/palettes.json
+++ b/backend/data/palettes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "timestamp": "2025-09-24T15:31:10.012497",
+    "image_url": "https://via.placeholder.com/150",
+    "colours": [
+      "#123456",
+      "#abcdef",
+      "#ff9900"
+    ],
+    "theme": "Summer"
+  }
+]

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Black Styles Specific
+backend/data/


### PR DESCRIPTION
Added a sample palettes.json file with color palette data to backend/data. Updated frontend/.gitignore to exclude backend/data/ directory, likely to prevent tracking generated or user-uploaded data.