### PR TITLE
🚀 feat(api): Add outfits API routes with persistence  

### DIFF
--- a/backend/app/routes/outfits.py
+++ b/backend/app/routes/outfits.py
@@ -1,0 +1,40 @@
+# backend/app/routes/outfits.py
+from flask import Blueprint, request, jsonify
+from app.services import outfit_service
+
+# New: Define a Flask Blueprint for outfit-related API routes
+bp = Blueprint("outfits", __name__, url_prefix="/api/outfits")
+
+@bp.route("/save", methods=["POST"])
+def save_outfit():
+    """
+    Save an outfit entry.
+    Expects JSON body containing:
+    - image_url: URL of the outfit image
+    - colours: extracted colour palette (list of hex values)
+    - theme: dectected theme for the outfit
+    Returns saved entry with metadata.
+    """
+    data = request.json
+    image_url = data.get("image_url")
+    colours = data.get("colours")
+    theme = data.get("theme")
+
+    # Validate required fields to prevent saving incomplete data
+    if not image_url or not colours:
+        return jsonify({"error": "Missing imageUrl or colours fields"}), 400
+    
+    # Save ourfit via service layer (keeps routes thin & clean)
+    entry = outfit_service.save_outfit(image_url, colours, theme)
+    return jsonify({"message": "Outfit saved", "entry": entry}), 201
+
+@bp.route("/recent", methods=["GET"])
+def get_recent_outfits():
+    """
+    Fetch the most recent outfits.
+    Accepts optional query param:
+    - limit: number of outfits to return (default 5)
+    """
+    limit = int(request.args.get("limit", 5))
+    outfits = outfit_service.get_recent_outfits(limit=limit)
+    return jsonify({"outfits": outfits})


### PR DESCRIPTION
**Summary:**  
This PR introduces new Flask API routes for saving and retrieving outfits. It integrates with the persistence service, validates input, and sets up a scalable Blueprint structure for future outfit-related endpoints.  

---

**Before vs After:**  

| Area               | Before  | After                                                            |
| ------------------ | ------- | ---------------------------------------------------------------- |
| **File existence** | No file | ✅ Introduced new Flask routes for outfits.                       |
| **API Routes**     | None    | ✅ Added `/api/outfits/save` (POST) for persisting outfits.       |
| **Validation**     | None    | ✅ Ensures `imageUrl` and `colors` must be present before saving. |
| **Service Layer**  | None    | ✅ Calls `outfit_service` to handle persistence logic.            |
| **New Endpoint**   | None    | ✅ Added `/api/outfits/recent` (GET) to fetch latest saved items. |
| **Extensibility**  | N/A     | ✅ Blueprint structure allows for future outfit-related routes.   |

---

**Actionable Summary:**  
- 🆕 Created new `outfits` Blueprint for API routes.  
- 💾 Implemented `/api/outfits/save` (POST):  
  - Validates required fields (`imageUrl`, `colors`).  
  - Persists outfit via `outfit_service`.  
- 📦 Implemented `/api/outfits/recent` (GET):  
  - Fetches latest saved outfits.  
  - Supports optional `limit` query param.  
- 🛠️ Ensured separation of concerns:  
  - Routes = HTTP logic.  
  - Service = persistence logic.  
- 🔮 Prepared structure for scalability → more endpoints (e.g., delete, update) can be added easily.  

---

**Next Steps:**  
- [ ] Add integration tests for `/api/outfits/save` and `/api/outfits/recent`.  
- [ ] Extend validation to include `theme` and timestamp consistency.  
- [ ] Plan schema extension for user-specific outfits.  
