### PR TITLE
Fix variable assignment typo in _save_outfit

### DIFF
--- a/backend/app/services/outfit_service.py
+++ b/backend/app/services/outfit_service.py
@@ -37,7 +37,7 @@ def _save_outfit(image_url, colours, theme):
     - theme: matched them result
     Each entry is timestamped to maintain history.
     """
-    outfits - _load_outfits()
+    outfits = _load_outfits()
     entry = {
         "timestamp": datetime.utcnow().isoformat(), # New: track when the outfit was saved
         "image_url": image_url,


### PR DESCRIPTION
Corrected a typo in the _save_outfit function where the outfits variable was incorrectly assigned with a hyphen instead of an equals sign.