### PR TITLE
🔗 feat(app): Register outfits blueprint in Flask app  

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,40 +1,48 @@
 # backend/app/__init__.py
 """
-Flask app factory
-- Initializes Flask instance
-- Enables CORS for frontend-backend communication
-- Registers Blueprints for modular routes:
-  - image routes (/api/image)
-  - test routes (/api/test)
-  - theme routes (/api/theme) ← newly added
+Flask App Factory
+-----------------
+- Creates and configures the Flask backend app.
+- Enables CORS so the React frontend can talk to the backend.
+- Registers all routes blueprints (Modular APIs):
+  - /api/image    → Image upload + color extraction
+  - /api/test     → Health check endpoint
+  - /api/theme    → Palette → theme matching
+  - /api/outfit   → Outfit persistence layer (New ✅)
 """
 
 from flask import Flask
 from flask_cors import CORS # Allows cross-origin requests (essential for frontend-backend communication)
 
+# ✅ NEW: Import the new outfits blueprint
+from app.routes import outfits 
+
 def create_app():
     # Initialize the Flask app instance
     app = Flask(__name__)
 
-    # Enable CORS so the frontend (e.g., React) can communicate with the backend
+    # Enable cross-origin requests (important when frontend & backend run on different ports)
     CORS(app)
 
-    # Import and register the image-related routes as a blueprint
-    from .routes.routes import image_routes, api_bp # Importing existing image and API routes
-    from .routes.test import test_routes # Registering new test route for backend verification
-    from .routes.theme import theme_bp # Import the new theme routes
+    # Import existing routes blueprints locally to avoid circular imports
+    from .routes.routes import image_routes, api_bp
+    from .routes.test import test_routes
+    from .routes.theme import theme_bp 
     
-    # Register image-related routes under /api/image
-    app.register_blueprint(image_routes, url_prefix="/api/image") # This allows image upload and color extraction functionality
+    # Register image routes (upload + extract colours)
+    app.register_blueprint(image_routes, url_prefix="/api/image")
 
-    # Register test routes under /api/test
-    app.register_blueprint(test_routes) # This allows quick health checks of the backend
+    # Register test routes (backend health check)
+    app.register_blueprint(test_routes) 
 
-    # Register theme-related routes under /api/theme
-    app.register_blueprint(theme_bp) # This allows palette to theme matching functionality
+    # Register theme routes (palette → theme matching)
+    app.register_blueprint(theme_bp)
 
-    # Register the main API blueprint which contains the palettes routes
+    # Register palettes routes (already grouped under api_bp)
     app.register_blueprint(api_bp)
+
+    # ✅ NEW: Register outfits persistence routes
+    app.register_blueprint(outfits.bp)
 
     # Return the fully configured app instance
     return app


### PR DESCRIPTION
**Summary:**  
This PR integrates the new **Outfits API blueprint** into the Flask app factory, enabling persistence routes for saving and retrieving outfits. It also improves documentation and maintains a consistent registration structure across all blueprints.  

---

**Before vs After:**  

| Area              | Before                                           | After                                                              |
| ----------------- | ------------------------------------------------ | ------------------------------------------------------------------ |
| **Imports**       | No `outfits` import                              | ✅ Added `from app.routes import outfits`                           |
| **Blueprints**    | Registered `image`, `test`, `theme`, `api_bp`    | ✅ Registered new `outfits.bp` for persistence API                  |
| **Functionality** | Supported image, test, theme, and palette routes | ✅ Added **outfit persistence layer** for saving + retrieving items |
| **Documentation** | Brief docstring                                  | ✅ Expanded docstring to clearly describe each route (incl. outfits)|

---

**Actionable Summary:**  
- 🆕 Imported `outfits` blueprint from `app.routes`.  
- 🔗 Registered outfits routes (`/api/outfits/save`, `/api/outfits/recent`) into the app factory.  
- 📝 Updated module docstring & inline comments to clarify route responsibilities.  
- ♻️ Improved maintainability by consolidating route registration in a consistent, extensible structure.  

---

**Next Steps:**  
- [ ] Add integration tests for `/api/outfits/save` and `/api/outfits/recent`.  
- [ ] Expand docstring with endpoint usage examples.  
- [ ] Prepare for future routes (update/delete outfits).  
