### PR TITLE
Call private _save_outfit method in save_outfit route

### DIFF
--- a/backend/app/routes/outfits.py
+++ b/backend/app/routes/outfits.py
@@ -25,7 +25,7 @@ def save_outfit():
         return jsonify({"error": "Missing imageUrl or colours fields"}), 400
     
     # Save ourfit via service layer (keeps routes thin & clean)
-    entry = outfit_service.save_outfit(image_url, colours, theme)
+    entry = outfit_service._save_outfit(image_url, colours, theme)
     return jsonify({"message": "Outfit saved", "entry": entry}), 201
 
 @outfits_bp.route("/recent", methods=["GET"])


### PR DESCRIPTION
Updated the save_outfit route to use the private _save_outfit method from the outfit_service instead of the public save_outfit. This may reflect a change in the service layer's API or a need to access specific internal logic.