### PR TITLE
✨ feat(backend): Add tags persistence with safe defaults and API support

### DIFF
--- a/backend/app/routes/outfits.py
+++ b/backend/app/routes/outfits.py
@@ -14,20 +14,22 @@ def save_outfit():
     - colours: extracted colour palette (list of hex values)
     - theme: dectected theme for the outfit
     - caption: (optional) descriptive text provided by the user
+    - tags: (optional) list of user-specified tags for categorization
     Returns saved entry with metadata.
     """
     data = request.json
     image_url = data.get("image_url")
     colours = data.get("colours")
     theme = data.get("theme")
-    caption = data.get("caption", "") # ✅ NEW: optional caption field
+    caption = data.get("caption", "")
+    tags = data.get("tags", []) # ✅ NEW: allow tags persistence
 
     # Validate required fields to prevent saving incomplete data
     if not image_url or not colours:
         return jsonify({"error": "Missing imageUrl or colours fields"}), 400
     
-    # ✅ UPDATED: pass caption into service layer
-    entry = outfit_service._save_outfit(image_url, colours, theme, caption)
+    # ✅ UPDATED: pass tags into service layer
+    entry = outfit_service._save_outfit(image_url, colours, theme, caption, tags)
     return jsonify({"message": "Outfit saved", "entry": entry}), 201
 
 @outfits_bp.route("/recent", methods=["GET"])

--- a/backend/app/services/outfit_service.py
+++ b/backend/app/services/outfit_service.py
@@ -3,7 +3,7 @@ import json
 import os
 from datetime import datetime
 
-# New: Define path where outfits data will will be persisted (inside backend/data/)
+# Path where outfits will be stored (inside backend/data/outfits.json)
 DATA_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "data", "outfits.json")
 
 def _load_outfits():
@@ -21,25 +21,33 @@ def _save_outfits(outfits):
     with open(DATA_FILE, "w") as f:
         json.dump(outfits, f, indent=2)
 
-# 🔄 CHANGED: Added optional `caption` parameter (default empty string)
-def _save_outfit(image_url, colours, theme, caption=None):
+# ✅ UPDATED: Added optional `tags` parameter (default empty string)
+def _save_outfit(image_url, colours, theme, caption="", tags=None):
     """
-    Save a new outfit consisting of:
-    - image_url: where the outfit image is stored
-    - colours: extracted palette
-    - theme: matched them result
-    - caption: (optional) user-provided description
-    Each entry is timestamped and inserted at the front for recency.
+    Save a new outfit entry
+    Args:
+     image_url (str): Url of the outfit image
+     colours (list[str]): extracted  colour palette (hex codes)
+     theme (str): detected outfit theme
+     caption (str, optional): user-provided description
+     tags (list[str], optional): user-provided tags for categorization
+    Returns:
+        dict: persisted outfit entry
     """
-    outfits = _load_outfits()
+    if tags is None:
+        tags = [] # ✅ Ensure tags is always a list (avoid NoneType issues)
+
     entry = {
-        "timestamp": datetime.utcnow().isoformat(), # New: track when the outfit was saved
+        "timestamp": datetime.utcnow().isoformat(), # track when saved
         "image_url": image_url,
         "colours": colours,
         "theme": theme,
-        "caption": caption or ""  # ✅ New: supports caption, (default to empty string)
+        "caption": caption,
+        "tags": tags # ✅ New: tags now persisted
     }
-    outfits.insert(0, entry)  # New: Insert at the beginning so newest is always first
+
+    outfits = _load_outfits()
+    outfits.insert(0, entry)  # ✅Keep newest outfits at the top
     _save_outfits(outfits)
     return entry
 


### PR DESCRIPTION
# ✨ feat(outfits): Add optional tags support to API persistence

---

## 📋 Summary
Extended the outfits API to support **optional tags** when saving outfits.  
This enables richer metadata, allowing users to categorize and filter outfits more effectively.

---

## 🔍 Highlights of Changes
- **Added field**:  
  ```python
  tags = data.get("tags", [])
</code></pre>
<p>→ Enables saving optional tags.</p>
<ul>
<li>
<p><strong>Updated service call</strong>:</p>
<pre><code class="language-python">outfit_service.save_outfit(image_url, colors, theme, caption, tags)
</code></pre>
<p>→ Ensures tags are persisted to the backend.</p>
</li>
<li>
<p><strong>Validation</strong>:</p>
<ul>
<li>
<p>Error handling continues to enforce <code inline="">image_url</code> and <code inline="">colors</code>.</p>
</li>
<li>
<p><code inline="">tags</code> remains optional, defaults to an empty list.</p>
</li>
</ul>
</li>
</ul>
<hr>
<h2>📑 Actionable Summary</h2>

Area | Before | After
-- | -- | --
Request parsing | Only supported image_url, colours, theme, caption | Added support for tags field alongside caption, colors, theme, and image URL
Service call | outfit_service._save_outfit(image_url, colours, theme, caption) | outfit_service.save_outfit(image_url, colours, theme, caption, tags)
Flexibility | No tagging support | ✅ Outfits can now be categorized or filtered by user-provided tags


<hr>
<h2>🚀 Actionable Outcomes</h2>
<ul>
<li>
<p>Outfits can now store <strong>user-defined tags</strong> for better organization.</p>
</li>
<li>
<p>Backend service and persistence layer aligned with new data structure.</p>
</li>
<li>
<p>Fully backward compatible: tags default to an empty list if not provided.</p>
</li>
</ul>
<hr>
<h2>📌 Next Steps</h2>
<ul>
<li>
<p>Extend frontend form to allow users to add/edit tags.</p>
</li>
<li>
<p>Build filtering UI for tags (search by keyword, group by tag, etc.).</p>
</li>
</ul>