### PR TITLE
✨ feat(frontend): Add combined tag & theme search with sidebar filters and outfit grid refinements

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,4 @@
+/* frontend/src/index.css */
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -67,9 +68,9 @@ button:focus-visible {
   }
 }
 
-/* Outfit grif layout for RecentOutfits and similar components*/
+/* Outfit grid layout for RecentOutfits and similar components */
 .outfit-grid {
-  display: grid; /* Outfit grid layout for RecentOutfits and similar components*/
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); /* Responsive 220px min, expand to fill row*/
-  gap: 16px; /* Space between cards*/
+  display: grid; /* Enables responsive grid for outfit cards */
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); /* Minimum card width 220px, expand to fill row */
+  gap: 16px; /* Gap between cards for spacing */
 }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -31,15 +31,18 @@ export async function fetchOutfits(limit = 5){
 }
 
 /**
- * Search outfits by mutiple tags.
- * - Why: Enablrd advanced filtering so users can refine results (e.g., "summer, casual").
- * - Example: searchOutfitsByTag(["summer", "casual"])
+ * Search outfits by mutiple tags and optional theme.
+ * - Why: Adds more powerful filtering by combining tags and themes.
+ * - Example: searchOutfits(["summer", "casual"], "streetwear")
  */
-export async function searchOutfitsByTag(tags){
-    // ✅ Backend expects tags as a comma-separated string (e.g., "summer,casual")
+export async function searchOutfits(tags = [], theme = ""){
+    // ✅ Backend expects tags as a comma-separated string and theme as plain string
     // ✅ Using axios `params` safely encodes query strings to avoid injection issues
     const res = await axios.get(`${API_BASE}/outfits/search`, { 
-        params: { tags: tags.join(",") }, // Join array into a single string
+        params: { 
+            tags: tags.join(","), // Join array into a single string
+            theme // Optional theme filter
+        }, 
     });
 
     // ✅ Return only the outfits array to keep UI consumption simple


### PR DESCRIPTION
# ✨ feat(api): Extend searchOutfits to support tags + optional theme

## Highlights of Changes
- **Renamed function**: `searchOutfitsByTag` → `searchOutfits` (clearer, more flexible).  
- **Added parameter**: `theme` (optional string filter).  
- **Extended API call**: Now sends both `tags` and `theme` as query params.  
- **Improved docstring**: Explains combined search logic and provides example usage.  

## Summary of Changes
| Area              | Before                                     | After                                                         |
| ----------------- | ------------------------------------------ | ------------------------------------------------------------- |
| Function name     | `searchOutfitsByTag` (only tags supported) | `searchOutfits` (supports tags + optional theme)              |
| Search capability | Filtered outfits **only by tags**          | Can filter outfits by **tags, theme, or both simultaneously** |
| Parameters        | `tags` (array of strings)                  | `tags` (array) + `theme` (optional string)                    |
| API query params  | `tags: tags.join(",")`                     | `tags: tags.join(",")`, `theme`                               |
| Documentation     | Example limited to tags                    | Updated example includes **tags + theme** for clarity         |

## Concise Explanation
We enhanced the API utility by renaming `searchOutfitsByTag` to `searchOutfits`, making it more intuitive and adaptable.  
The function now supports **combined filtering by multiple tags and/or a theme**, giving users more precise search options.  
An improved docstring was added with clear examples to guide developers on usage.  
